### PR TITLE
Check /opt/homebrew share for bundled debug-tools

### DIFF
--- a/Sources/GUIApp.swift
+++ b/Sources/GUIApp.swift
@@ -144,7 +144,8 @@ private func bundledMCPServerCandidates() -> [String] {
     // Current working directory (for running from repo root)
     candidates.append(FileManager.default.currentDirectoryPath + "/mcp/debug-tools/server.py")
 
-    // Installed location
+    // Installed locations
+    candidates.append("/opt/homebrew/share/apfel-gui/mcp/debug-tools/server.py")
     candidates.append("/usr/local/share/apfel-gui/mcp/debug-tools/server.py")
 
     return candidates


### PR DESCRIPTION
Homebrew installs `apfel-gui` under `/opt/homebrew/share/...` on Apple Silicon, but `bundledMCPServerCandidates()` only checks `/usr/local/share/...` for the installed debug-tools server.

This adds the `/opt/homebrew/share/apfel-gui/mcp/debug-tools/server.py` installed path alongside the existing `/usr/local/...` check so bundled debug-tools are discovered from a normal Apple Silicon Homebrew install.